### PR TITLE
Add public install script

### DIFF
--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo "Cloning Sublime Platform repo"
+if ! git clone https://github.com/sublime-security/sublime-platform.git;
+then
+  echo "Failed to clone Sublime Platform repo"
+  exit 1
+fi
+
+echo "Launching Sublime Platform"
+cd sublime-platform || { echo "Failed to cd into sublime-platform"; exit 1; }
+
+./launch-sublime-platform.sh


### PR DESCRIPTION
## Context

In order to improve our onboarding experience, we are introducing a one-liner that will allow users to install and launch the Sublime Platform. The Quickstart guide will have the following command:

`curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | bash`

We will also be using this command in our CI pipelines to ensure that the installation experience isn't broken.

## Tests

* Ran `curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/hugh.install-script/install-and-launch.sh | bash`
  * Images were pulled correctly
  * Docker compose ran images properly