### PR TITLE
Allow sublime host to be configured

### DIFF
--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -1,5 +1,36 @@
 #!/usr/bin/env bash
 
+: ==========================================
+:   Introduction
+: ==========================================
+
+# This script allows you to install the latest version of the Sublime Platform by running:
+#
+: curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | bash
+#
+# Note: lines prefixed with ":" are no-ops but still retain syntax highlighting. Bash considers ":" as true and true can
+# take an infinite number of arguments and still return true. Inspired from the Firebase tool installer.
+
+: ==========================================
+:   Advanced Usage
+: ==========================================
+
+# You can change the behavior of this script by passing environmental variables to the bash process. For example:
+#
+: curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | arg1=foo arg2=bar bash
+#
+
+: -----------------------------------------
+:  Sublime Host - default: localhost
+: -----------------------------------------
+
+# By default, this script assumes that Sublime is deployed locally. If you installed Sublime on a remote VPS or VM,
+# you'll need to specify IP address of your remote system.
+#
+: curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | sublime_host=0.0.0.0 bash
+#
+# Replace 0.0.0.0 with the IP address of your remote system.
+
 echo "Cloning Sublime Platform repo"
 if ! git clone https://github.com/sublime-security/sublime-platform.git;
 then
@@ -11,3 +42,5 @@ echo "Launching Sublime Platform"
 cd sublime-platform || { echo "Failed to cd into sublime-platform"; exit 1; }
 
 ./launch-sublime-platform.sh
+
+open "$(grep 'DASHBOARD_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)"

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -31,30 +31,63 @@ else
     echo "Uncommitted changes present, ignoring updates to sublime-platform git repo"
 fi
 
-# TODO support checking for specific keys and generating as needed
+if [ -z "$sublime_host" ]; then
+  sublime_host=localhost
+fi
+
 SUBLIME_ENV_FILE=sublime.env
 
-if [[ -f "$SUBLIME_ENV_FILE" ]]; then
-    echo "$SUBLIME_ENV_FILE exists already!"
-else
+if ! grep "POSTGRES_PASSWORD" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
     POSTGRES_PASSWORD=$(openssl rand -hex 24)
-    JWT_SECRET=$(openssl rand -hex 24)
-     # note: key length must be 16, 24, or 32 bytes
-    POSTGRES_ENCRYPTION_KEY=$(openssl rand -hex 32)
-    FAKE_AWS_ACCESS_KEY_ID=$(openssl rand -hex 32)
-    FAKE_AWS_SECRET_ACCESS_KEY=$(openssl rand -hex 32)
-
     echo "POSTGRES_PASSWORD=$POSTGRES_PASSWORD" >> $SUBLIME_ENV_FILE
-    echo "JWT_SECRET=$JWT_SECRET" >> $SUBLIME_ENV_FILE
-    echo "POSTGRES_ENCRYPTION_KEY=$POSTGRES_ENCRYPTION_KEY" >> $SUBLIME_ENV_FILE
-    echo "CORS_ALLOW_ORIGINS=http://localhost:3000" >> $SUBLIME_ENV_FILE
-    echo "BASE_URL=http://localhost:8000" >> $SUBLIME_ENV_FILE
-    echo "DASHBOARD_PUBLIC_BASE_URL=http://localhost:3000" >> $SUBLIME_ENV_FILE
-    echo "API_PUBLIC_BASE_URL=http://localhost:8000" >> $SUBLIME_ENV_FILE
-    echo "AWS_ACCESS_KEY_ID=fake_$FAKE_AWS_ACCESS_KEY_ID" >> $SUBLIME_ENV_FILE
-    echo "AWS_SECRET_ACCESS_KEY=fake_$FAKE_AWS_SECRET_ACCESS_KEY" >> $SUBLIME_ENV_FILE
+    echo "Configured Postgres password"
+fi
 
-    echo "Successfully generated $SUBLIME_ENV_FILE"
+if ! grep "JWT_SECRET" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+    JWT_SECRET=$(openssl rand -hex 24)
+    echo "JWT_SECRET=$JWT_SECRET" >> $SUBLIME_ENV_FILE
+    echo "Configured JWT secret"
+fi
+
+if ! grep "POSTGRES_ENCRYPTION_KEY" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+     # Note: key length must be 16, 24, or 32 bytes
+    POSTGRES_ENCRYPTION_KEY=$(openssl rand -hex 32)
+    echo "POSTGRES_ENCRYPTION_KEY=$POSTGRES_ENCRYPTION_KEY" >> $SUBLIME_ENV_FILE
+    echo "Configured Postgres encryption key"
+fi
+
+if ! grep "AWS_ACCESS_KEY_ID" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+     # Note: key length must be 16, 24, or 32 bytes
+    FAKE_AWS_ACCESS_KEY_ID=$(openssl rand -hex 32)
+    echo "AWS_ACCESS_KEY_ID=fake_$FAKE_AWS_ACCESS_KEY_ID" >> $SUBLIME_ENV_FILE
+    echo "Configured AWS access key ID"
+fi
+
+if ! grep "AWS_SECRET_ACCESS_KEY" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+     # Note: key length must be 16, 24, or 32 bytes
+    FAKE_AWS_SECRET_ACCESS_KEY=$(openssl rand -hex 32)
+    echo "AWS_SECRET_ACCESS_KEY=fake_$FAKE_AWS_SECRET_ACCESS_KEY" >> $SUBLIME_ENV_FILE
+    echo "Configured AWS secret access key"
+fi
+
+if ! grep "CORS_ALLOW_ORIGINS" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+    echo "CORS_ALLOW_ORIGINS=http://$sublime_host:3000" >> $SUBLIME_ENV_FILE
+    echo "Configured CORS allow origins"
+fi
+
+if ! grep "BASE_URL" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+    echo "BASE_URL=http://$sublime_host:8000" >> $SUBLIME_ENV_FILE
+    echo "Configured base URL"
+fi
+
+if ! grep "DASHBOARD_PUBLIC_BASE_URL" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+    echo "DASHBOARD_PUBLIC_BASE_URL=http://$sublime_host:3000" >> $SUBLIME_ENV_FILE
+    echo "Configured dashboard URL"
+fi
+
+if ! grep "API_PUBLIC_BASE_URL" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
+    echo "API_PUBLIC_BASE_URL=http://$sublime_host:8000" >> $SUBLIME_ENV_FILE
+    echo "Configured API URL"
 fi
 
 $cmd_prefix docker-compose pull && $cmd_prefix docker-compose up -d


### PR DESCRIPTION
## Context

We allow for remote deployments of the Sublime Platform but all the scripts assume that deployment is happening locally. These changes allows users to override their deployment host to an IP of their choice.

## Changes

* `update-and-run.sh` now checks for individual values in `sublime.env` and sets them if they are missing
* Host can be overridden by specifying the `sublime_host` env variable when executing bash
* Added comments
* Open the dashboard after installation
  * This will fully encapsulate all the quickstart steps

## Tests

* Verified fresh install with default host
* Verified fresh install with specified host
* Removed various fields from `sublime.env` and they were restored