### PR TITLE
Add interactivity to installation script

### DIFF
--- a/launch-sublime-platform.sh
+++ b/launch-sublime-platform.sh
@@ -55,7 +55,7 @@ if [[ "${?}" == "1" ]]; then
 	echo "Adding daily update check"
 	(crontab -l 2>/dev/null; echo "0 12 * * * ""$update_command") | crontab -
 else
-	echo "daily update check is already setup"
+	echo "Daily update check is already setup"
 fi
 
 echo "Updating and running!"


### PR DESCRIPTION
## Context

The current installation experience is bifurcated based on where Sublime is deployed (locally vs remotely). We can consolidate the installation commands by prompting users on where their Sublime instance is deployed. All the interactivity can be disabled since we're going to want to run this in a CI environment at some point.

See #34 for further context.

More changes are likely required for CI to work but that's for a subsequent PR.

## Testing

* Interactivity is on by default
* Specifying a host or IP with leading and trailing whitespace gets pruned properly
* Only whitespace defaults to `localhost`
* Opening the dashboard can be disabled
* Interactivity can be disabled
* `sublime_host` is propagated to other scripts