### PR TITLE
Various install script UX improvements

### DIFF
--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -63,6 +63,10 @@
 : curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | open_dashboard=false bash
 #
 
+if ! ./preflight_checks.sh; then
+    exit 1
+fi
+
 if [ -z "$interactive" ]; then
     interactive="true"
 fi
@@ -89,12 +93,21 @@ fi
 
 
 echo "Launching Sublime Platform"
-sublime_host=$sublime_host ./launch-sublime-platform.sh
+# We are skipping preflight checks because we've already performed them at the start of this script
+if ! sublime_host=$sublime_host skip_preflight=true ./launch-sublime-platform.sh; then
+    echo "Failed to launch Sublime Platform"
+    exit 1
+fi
+
+echo "Successfully installed Sublime Platform!"
+echo "It may take a couple of minutes for all services to start for the first time"
 
 if [ -z "$open_dashboard" ]; then
     open_dashboard="true"
 fi
 
-if [ "$open_dashboard" == "true" ]; then
-    open "$(grep 'DASHBOARD_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)"
+dashboard_url=$(grep 'DASHBOARD_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)
+if [ "$open_dashboard" == "true" ] && [ ! -z "$dashboard_url" ]; then
+    echo "Opening Sublime Dashboard"
+    open "$dashboard_url"
 fi

--- a/launch-sublime-platform.sh
+++ b/launch-sublime-platform.sh
@@ -1,57 +1,13 @@
 #!/bin/bash
 
-echo "Validating that docker (non-snap) and docker-compose (standalone not plugin) are installed"
-echo "Ubuntu snap packages will be rejected"
-
-# Startup version checks
-which docker
-if [[ "${?}" != "0" ]]; then
-	echo "docker not installed. Please install docker and retry"
-	exit 1
-fi
-
-which docker-compose
-if [[ "${?}" != "0" ]]; then
-    echo "docker-compose not installed. Please install docker-compose and retry"
-	exit 1
-fi
-
-which cron
-if [[ "${?}" != "0" ]]; then
-    echo "cron not installed. Please install cron and retry"
-	exit 1
-fi
-
-which systemctl
-if [[ "${?}" == "0" ]]; then
-    systemctl status cron
-    if [[ "${?}" != "0" ]]; then
-        # this check may not be reliable if some other init system is used, or maybe cron was temp disabled.
-        echo "cron may not be running! Will proceed, but auto updates will not function without cron"
-    fi
-fi
-
-# snap, an ubuntu package manager, versions of docker won't play nicely with compose
-# reject these early and recommend users contact us if needed. Nothing specific about
-# our software is related to snap issues, but we don't want anyone to uninstall snap
-# docker without realizing they could loose data (from our platform or other applications).
-which snap
-if [[ "${?}" == "0" ]]; then
-	snap list | grep -i docker
-	if [[ "${?}" == "0" ]]; then
-		echo "snap versions of docker software detected! Cannot proceed."
-		echo "snap versions of docker are not recommended and can cause issues when using compose in the future (e.g. cannot bring containers down)"
-		echo "please uninstall snap docker packages and install with apt"
-		echo "If you have existing docker containers or volumes or are otherwise unsure, please contact support@sublimesecurity.com for assistance"
-		exit 1
-	fi
+if ! ./preflight_checks.sh; then
+    exit 1
 fi
 
 # If this command is modified we might need a more sophisticated check below (worse case is more updates than intended)
 update_command="cd ""$(pwd)"" && ./update-and-run.sh"
 
-crontab -l | grep "$update_command"
-if [[ "${?}" == "1" ]]; then
+if ! crontab -l | grep "$update_command" > /dev/null 2>&1; then
 	echo "Adding daily update check"
 	(crontab -l 2>/dev/null; echo "0 12 * * * ""$update_command") | crontab -
 else

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2154
+if [ "$skip_preflight" == "true" ]; then
+    exit 0
+fi
+
+echo "Validating that docker (non-snap) and docker-compose (standalone not plugin) are installed"
+echo "Ubuntu snap packages will be rejected"
+
+if ! which docker > /dev/null 2>&1; then
+	echo "docker not installed. Please install docker and retry (https://docs.docker.com/get-docker/)"
+	exit 1
+fi
+
+if ! which docker-compose > /dev/null 2>&1; then
+    echo "docker-compose not installed. Please install docker-compose and retry (https://docs.docker.com/compose/install/)"
+	exit 1
+fi
+
+if ! which cron > /dev/null 2>&1; then
+    echo "cron not installed. Please install cron and retry"
+	exit 1
+fi
+
+if which systemctl > /dev/null 2>&1 && ! systemctl status cron > /dev/null 2>&1; then
+    # this check may not be reliable if some other init system is used, or maybe cron was temp disabled.
+    echo "cron may not be running! Will proceed, but auto updates will not function without cron"
+fi
+
+# snap, an ubuntu package manager, versions of docker won't play nicely with compose
+# reject these early and recommend users contact us if needed. Nothing specific about
+# our software is related to snap issues, but we don't want anyone to uninstall snap
+# docker without realizing they could loose data (from our platform or other applications).
+if which snap > /dev/null 2>&1 && snap list | grep -i docker > /dev/null 2>&1; then
+    echo "snap versions of docker software detected! Cannot proceed."
+    echo "snap versions of docker are not recommended and can cause issues when using compose in the future (e.g. cannot bring containers down)"
+    echo "please uninstall snap docker packages and install with apt"
+    echo "If you have existing docker containers or volumes or are otherwise unsure, please contact support@sublimesecurity.com for assistance"
+    exit 1
+fi

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -5,13 +5,13 @@ cmd_prefix="sudo "
 
 # Docker setups on OS X generally won't need sudo
 # TODO this check is pretty naive -- a properly setup docker/compose setup in Linux won't need sudo either
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    cmd_prefix=""
-fi
+case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    linux*)     cmd_prefix="sudo ";;
+    darwin*)    cmd_prefix="";;
+esac
 
 if [[ "$1" != "always_launch" ]]; then
-    $cmd_prefix docker-compose ps | grep "mantis"
-    if [[ "${?}" != "0" ]]; then
+    if ! $cmd_prefix docker-compose ps | grep "mantis" > /dev/null 2>&1; then
         echo "docker-compose appears to be brought down. Will not proceed to avoid relaunching."
         exit 0
     fi


### PR DESCRIPTION
# Context

Based off of initial usage feedback, there were some UX improvements that could be made. These changes don't actually affect the operations being performed but just the order and output of the operations.

# Changes

* Added links for installing Docker and Docker Compose when they are not installed
* Skip opening Sublime dashboard if previous script fails
* Refactored system checks into another script: `preflight_checks.sh`
* Moved preflight checks to the beginning of the installation script to minimize the chance of being in a bad state
* Added completion message with disclaimer about having to wait for services to start up the first time
* Suppressed command outputs when doing checks
  * This caused the output to be somewhat noisy and a bit confusing

# Tests

* Manually inverted each preflight check to ensure it wasn't noisy and working
* Checked that preflight check was skipped the second time when installing
* Checked for any regressions with `launch-sublime-platform.sh`