### PR TITLE
Fix preflight script to pull from curl

### DIFF
--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -63,7 +63,7 @@
 : curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | open_dashboard=false bash
 #
 
-if ! ./preflight_checks.sh; then
+if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/preflight_checks.sh | bash; then
     exit 1
 fi
 


### PR DESCRIPTION
# Context

Fixed a bug where we were attempting to call the preflight checks before cloning the repo. We will now just call it via curl instead.

# Testing

Called the script from `/tmp` and ensured that the one-liner preflight works.