### PR TITLE
Fix nightly cron update command

### DIFF
--- a/launch-sublime-platform.sh
+++ b/launch-sublime-platform.sh
@@ -5,7 +5,7 @@ if ! ./preflight_checks.sh; then
 fi
 
 # If this command is modified we might need a more sophisticated check below (worse case is more updates than intended)
-update_command="cd ""$(pwd)"" && ./update-and-run.sh"
+update_command="cd ""$(pwd)"" && bash -lc ./update-and-run.sh"
 
 if ! crontab -l | grep "$update_command" > /dev/null 2>&1; then
 	echo "Adding daily update check"


### PR DESCRIPTION
# Context

We add a crontab entry to update the Sublime Platform nightly. The issue is that cron runs with a default PATH that doesn't typically have `docker-compose`. This causes `update-and-run.sh` to bail in the context of a cron. By using a login shell, we can use the user's profile for the PATH.

Alternatively, we could explicitly set the PATH variable at the top of the crontab.

# Tests

I set the schedule to run every minute and dump the command contents out to a file. Verified that the cron was broken before the fix and working after the fix.