### PR TITLE
Add more guardrails to platform installation script

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -11,13 +11,18 @@ concurrency:
 
 jobs:
   tests:
-    name: Run Install Script Validation
+    name: Validate Platform Installation
     runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Validate Installation
+      - name: Install Platform
         run: |
           interactive=false clone_platform=false open_dashboard=false ./install-and-launch.sh
+
+      - name: Check Health
+        run: |
+          apt-get update && apt-get install -y yq
+          ./postflight_checks.sh

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Platform
         run: |
-          interactive=false clone_platform=false open_dashboard=false ./install-and-launch.sh
+          interactive=false clone_platform=false ./install-and-launch.sh
 
       - name: Check Health
         run: |

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -24,5 +24,4 @@ jobs:
 
       - name: Check Health
         run: |
-          apt-get update && apt-get install -y yq
           ./postflight_checks.sh

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -52,7 +52,6 @@
 : curl -sL https://sublimesecurity.com/install.sh | clone_platform=false bash
 #
 
-printf "\nRunning preflight checks\n"
 if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/preflight_checks.sh | bash; then
     exit 1
 fi
@@ -87,6 +86,9 @@ echo "Launching Sublime Platform"
 # We are skipping preflight checks because we've already performed them at the start of this script
 if ! sublime_host=$sublime_host skip_preflight=true ./launch-sublime-platform.sh; then
     echo "Failed to launch Sublime Platform"
+    echo "If you'd like to reinstall Sublime then follow the steps outline in https://docs.sublimesecurity.com/docs/quickstart-docker#wipe-postgres-volume"
+    echo "Afterwards, run: rm -rf ./sublime-platform"
+    echo "You can then go through the Sublime Platform installation again"
     exit 1
 fi
 

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -52,8 +52,7 @@
 : curl -sL https://sublimesecurity.com/install.sh | clone_platform=false bash
 #
 
-# FIXME: Revert back to main branch!
-if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/hugh.install-script-updates/preflight_checks.sh  | bash; then
+if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/preflight_checks.sh  | bash; then
     exit 1
 fi
 

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -52,17 +52,6 @@
 : curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | clone_platform=false bash
 #
 
-: -----------------------------------------
-:  Open Dashboard - default: true
-: -----------------------------------------
-
-# By default, this script assumes that it is being called through the quickstart one-liner. In that case, we want to
-# open the browser to the newly installed dashboard URL. Disabling this may be ideal in non-interactive environments
-# like CI.
-#
-: curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | open_dashboard=false bash
-#
-
 if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/preflight_checks.sh | bash; then
     exit 1
 fi
@@ -100,14 +89,6 @@ if ! sublime_host=$sublime_host skip_preflight=true ./launch-sublime-platform.sh
 fi
 
 echo "Successfully installed Sublime Platform!"
-echo "It may take a couple of minutes for all services to start for the first time"
-
-if [ -z "$open_dashboard" ]; then
-    open_dashboard="true"
-fi
-
 dashboard_url=$(grep 'DASHBOARD_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)
-if [ "$open_dashboard" == "true" ] && [ ! -z "$dashboard_url" ]; then
-    echo "Opening Sublime Dashboard"
-    open "$dashboard_url"
-fi
+echo "Your Sublime Dashboard is running at $dashboard_url"
+echo "It may take a couple of minutes for all services to start for the first time"

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -74,8 +74,10 @@ fi
 if [ "$clone_platform" == "true" ]; then
     echo "Cloning Sublime Platform repo"
     if ! git clone --depth=1 https://github.com/sublime-security/sublime-platform.git; then
-      echo "Failed to clone Sublime Platform repo"
-      exit 1
+        echo "Failed to clone Sublime Platform repo"
+        echo "See https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting for troubleshooting tips"
+        echo "You may need to run the following command before retrying installation: rm -rf ./sublime-platform"
+        exit 1
     fi
 
     cd sublime-platform || { echo "Failed to cd into sublime-platform"; exit 1; }
@@ -86,6 +88,7 @@ echo "Launching Sublime Platform"
 # We are skipping preflight checks because we've already performed them at the start of this script
 if ! sublime_host=$sublime_host skip_preflight=true ./launch-sublime-platform.sh; then
     echo "Failed to launch Sublime Platform"
+    echo "See https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting for troubleshooting tips"
     echo "If you'd like to reinstall Sublime then follow the steps outline in https://docs.sublimesecurity.com/docs/quickstart-docker#wipe-postgres-volume"
     echo "Afterwards, run: rm -rf ./sublime-platform"
     echo "You can then go through the Sublime Platform installation again"

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -52,6 +52,7 @@
 : curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/install-and-launch.sh | clone_platform=false bash
 #
 
+printf "\nRunning preflight checks\n"
 if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/preflight_checks.sh | bash; then
     exit 1
 fi
@@ -63,7 +64,8 @@ fi
 if [ "$interactive" == "true" ] && [ -z "$sublime_host" ]; then
     # Since this script is intended to be piped into bash, we need to explicitly read input from /dev/tty because stdin
     # is streaming the script itself
-    read -rp "Please specify where your Sublime is deployed (default: localhost): " sublime_host </dev/tty
+    printf "\nPlease specify the hostname or IP address of where you're deploying Sublime\n"
+    read -rp "(IP address or hostname of your VPS or VM | default: http://localhost): " sublime_host </dev/tty
 fi
 
 if [ -z "$clone_platform" ]; then

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -97,5 +97,5 @@ fi
 
 echo "Successfully installed Sublime Platform!"
 dashboard_url=$(grep 'DASHBOARD_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)
-echo "Your Sublime Dashboard is running at $dashboard_url"
 echo "It may take a couple of minutes for all services to start for the first time"
+echo "Your Sublime Dashboard is running at $dashboard_url"

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -52,7 +52,7 @@
 : curl -sL https://sublimesecurity.com/install.sh | clone_platform=false bash
 #
 
-if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/hugh.install-script-updates/preflight_checks.sh | bash; then
+if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/hugh.install-script-updates/preflight_checks.sh  | bash; then
     exit 1
 fi
 

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -52,6 +52,7 @@
 : curl -sL https://sublimesecurity.com/install.sh | clone_platform=false bash
 #
 
+# FIXME: Revert back to main branch!
 if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/hugh.install-script-updates/preflight_checks.sh  | bash; then
     exit 1
 fi

--- a/postflight_checks.sh
+++ b/postflight_checks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if ! which jq > /dev/null 2>&1; then
+    echo "Post-flight checks require jq to be installed. Please install jq and retry (https://stedolan.github.io/jq/download/)"
+    exit 1
+fi
+
+if [ -z "$timeout_minutes" ]; then
+    timeout_minutes=20
+fi
+
+if [ -z "$retry_interval_seconds" ]; then
+    retry_interval_seconds=5
+fi
+
+remaining_timeout_seconds=$(( timeout_minutes * 60 ))
+
+health_endpoint="$(grep 'API_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)/v1/health"
+while [ $remaining_timeout_seconds -gt 0 ]; do
+    echo "Attempting to check Sublime Platform health"
+
+    if [ "$(curl -s "$health_endpoint" | jq '.success')" == "true" ]; then
+        echo "Sublime Platform is healthy!"
+        exit 0
+    fi
+
+    if [ "$(curl -s "$health_endpoint" | jq '.success')" == "false" ]; then
+
+        echo "Sublime Platform is unhealthy. See details below:"
+        curl -s "$health_endpoint" | jq '.'
+        exit 1
+    fi
+
+    remaining_timeout_seconds=$(( remaining_timeout_seconds - retry_interval_seconds ))
+    sleep $retry_interval_seconds
+done
+
+echo "Unable to check Sublime Platform health due to timeout"
+exit 1

--- a/postflight_checks.sh
+++ b/postflight_checks.sh
@@ -13,7 +13,12 @@ if [ -z "$retry_interval_seconds" ]; then
     retry_interval_seconds=5
 fi
 
+if [ -z "$unhealthy_retries" ]; then
+    unhealthy_retries=3
+fi
+
 remaining_timeout_seconds=$(( timeout_minutes * 60 ))
+remaining_unhealthy_retries=$unhealthy_retries
 
 health_endpoint="$(grep 'API_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)/v1/health"
 while [ $remaining_timeout_seconds -gt 0 ]; do
@@ -25,9 +30,13 @@ while [ $remaining_timeout_seconds -gt 0 ]; do
     fi
 
     if [ "$(curl -s "$health_endpoint" | jq '.success')" == "false" ]; then
+        remaining_unhealthy_retries=$(( remaining_unhealthy_retries - 1 ))
+    fi
+
+    if [ $remaining_unhealthy_retries -lt 0 ]; then
         echo "Sublime Platform is unhealthy. See details below:"
         curl -s "$health_endpoint" | jq '.'
-#        exit 1
+        exit 1
     fi
 
     remaining_timeout_seconds=$(( remaining_timeout_seconds - retry_interval_seconds ))

--- a/postflight_checks.sh
+++ b/postflight_checks.sh
@@ -25,10 +25,9 @@ while [ $remaining_timeout_seconds -gt 0 ]; do
     fi
 
     if [ "$(curl -s "$health_endpoint" | jq '.success')" == "false" ]; then
-
         echo "Sublime Platform is unhealthy. See details below:"
         curl -s "$health_endpoint" | jq '.'
-        exit 1
+#        exit 1
     fi
 
     remaining_timeout_seconds=$(( remaining_timeout_seconds - retry_interval_seconds ))

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -144,3 +144,5 @@ if which snap > /dev/null 2>&1 && snap list | grep -i docker > /dev/null 2>&1; t
     echo "If you have existing docker containers or volumes or are otherwise unsure, please contact support@sublimesecurity.com for assistance"
     exit 1
 fi
+
+echo "Successfully completed preflight checks!"

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -54,6 +54,8 @@ if [ "$machine" == "linux" ]; then
         if version_lt "$(major_minor "$ubuntu_version")" "20.04"; then
             echo "Warning: Ubuntu version $ubuntu_version does not meet the recommended minimum version of 20.04"
         fi
+    else
+        echo "Warning: Non-Ubuntu Linux distributions are unsupported and subsequent failures may occur"
     fi
 fi
 

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -13,6 +13,11 @@ if ! which docker > /dev/null 2>&1; then
 	exit 1
 fi
 
+if ! docker info > /dev/null 2>&1; then
+	echo "docker is not running. Please start docker and retry"
+	exit 1
+fi
+
 if ! which docker-compose > /dev/null 2>&1; then
     echo "docker-compose not installed. Please install docker-compose and retry (https://docs.docker.com/compose/install/)"
 	exit 1

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -32,14 +32,13 @@ case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
 esac
 
 if [ -z "$machine" ]; then
-    echo "You are using a non-recommended operating system so subsequent failures may occur"
+    echo "Warning: You are using a non-recommended operating system so subsequent failures may occur"
 fi
 
 if [ "$machine" == "macos" ]; then
     macos_version="$(/usr/bin/sw_vers -productVersion)"
     if version_lt "$(major_minor "$macos_version")" "11.0"; then
-        echo "Mac OS version $macos_version does not meet the minimum version of 11.0. Please update your Mac OS and retry"
-        exit 1
+        echo "Warning: Mac OS version $macos_version does not meet the recommended minimum version of 11.0"
     fi
 fi
 
@@ -53,8 +52,7 @@ if [ "$machine" == "linux" ]; then
         # Should be "20.04.3"
         ubuntu_version=${ubuntu_version## *}
         if version_lt "$(major_minor "$ubuntu_version")" "20.04"; then
-            echo "Ubuntu version $ubuntu_version does not meet the minimum version of 20.04. Please update your Ubuntu OS and retry"
-            exit 1
+            echo "Warning: Ubuntu version $ubuntu_version does not meet the recommended minimum version of 20.04"
         fi
     fi
 fi

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -5,12 +5,100 @@ if [ "$skip_preflight" == "true" ]; then
     exit 0
 fi
 
-echo "Validating that docker (non-snap) and docker-compose (standalone not plugin) are installed"
-echo "Ubuntu snap packages will be rejected"
+echo "Running preflight checks"
+
+major_minor() {
+  echo "${1%%.*}.$(
+    x="${1#*.}"
+    echo "${x%%.*}"
+  )"
+}
+
+version_gt() {
+  [[ "${1%.*}" -gt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -gt "${2#*.}" ]]
+}
+
+version_ge() {
+  [[ "${1%.*}" -gt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -ge "${2#*.}" ]]
+}
+
+version_lt() {
+  [[ "${1%.*}" -lt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -lt "${2#*.}" ]]
+}
+
+case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    linux*)     machine=linux;;
+    darwin*)    machine=macos;;
+esac
+
+if [ -z "$machine" ]; then
+    echo "You are using a non-recommended operating system so subsequent failures may occur"
+fi
+
+if [ "$machine" == "macos" ]; then
+    macos_version="$(/usr/bin/sw_vers -productVersion)"
+    if version_lt "$(major_minor "$macos_version")" "11.0"; then
+        echo "Mac OS version $macos_version does not meet the minimum version of 11.0. Please update your Mac OS and retry"
+        exit 1
+    fi
+fi
+
+if [ "$machine" == "linux" ]; then
+    linux_name="$(grep 'NAME' /etc/os-release | cut -d'=' -f2 | tr '[:upper:]' '[:lower:]')"
+    if [ "$linux_name" == "ubuntu" ]; then
+        # "20.04.3 LTS (Focal Fossa)"
+        ubuntu_version="$(grep 'VERSION' /etc/os-release | cut -d'=' -f2)"
+
+        # Remove longest substring matching " *" starting from the front of the string
+        # Should be "20.04.3"
+        ubuntu_version=${ubuntu_version## *}
+        if version_lt "$(major_minor "$ubuntu_version")" "20.04"; then
+            echo "Ubuntu version $ubuntu_version does not meet the minimum version of 20.04. Please update your Ubuntu OS and retry"
+            exit 1
+        fi
+    fi
+fi
+
+if ! which git > /dev/null 2>&1; then
+    echo "git not installed. Please install git and retry (https://git-scm.com/downloads)"
+    exit 1
+fi
+
+# git --version -> git version 2.37.0 (Apple Git-136)
+git_version="$(git --version 2>/dev/null)"
+
+# Remove longest substring matching "*version " starting from the front of the string
+# Should be "2.37.0 (Apple Git-136)"
+git_version=${git_version##*version }
+
+# Remove longest substring matching " (*" starting from the end of the string
+# Should be "2.37.0"
+git_version=${git_version%% (*}
+
+if version_lt "$(major_minor "$git_version")" "2.7"; then
+    echo "git version $git_version does not meet the minimum version of 2.7. Please update git and retry"
+    exit 1
+fi
 
 if ! which docker > /dev/null 2>&1; then
 	echo "docker not installed. Please install docker and retry (https://docs.docker.com/get-docker/)"
 	exit 1
+fi
+
+# "Docker version 20.10.17, build 100c701"
+docker_version="$(docker --version 2>/dev/null)"
+
+# Remove longest substring matching "*version " starting from the front of the string
+# Should be "20.10.17, build 100c701"
+docker_version=${docker_version##*version }
+
+# Remove longest substring matching ", *" starting from the end of the string
+# Should be "20.10.17"
+docker_version=${docker_version%%, *}
+
+if version_lt "$(major_minor "$docker_version")" "20.10"; then
+    echo "docker version $docker_version does not meet the minimum version of 20.10. Please update docker and retry"
+    exit 1
 fi
 
 if ! docker info > /dev/null 2>&1; then
@@ -21,6 +109,18 @@ fi
 if ! which docker-compose > /dev/null 2>&1; then
     echo "docker-compose not installed. Please install docker-compose and retry (https://docs.docker.com/compose/install/)"
 	exit 1
+fi
+
+# "Docker Compose version v2.10.2"
+docker_compose_version="$(docker-compose --version 2>/dev/null)"
+
+# Remove longest substring matching "*version v" starting from the front of the string
+# Should be "2.10.2"
+docker_compose_version=${docker_compose_version##*version }
+
+if version_lt "$(major_minor "$docker_compose_version")" "2.10"; then
+    echo "docker-compose version $docker_compose_version does not meet the minimum version of 2.10. Please update docker-compose and retry"
+    exit 1
 fi
 
 if ! which cron > /dev/null 2>&1; then

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -116,7 +116,7 @@ docker_compose_version="$(docker-compose --version 2>/dev/null)"
 
 # Remove longest substring matching "*version v" starting from the front of the string
 # Should be "2.10.2"
-docker_compose_version=${docker_compose_version##*version }
+docker_compose_version=${docker_compose_version##*version v}
 
 if version_lt "$(major_minor "$docker_compose_version")" "2.10"; then
     echo "docker-compose version $docker_compose_version does not meet the minimum version of 2.10. Please update docker-compose and retry"

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -32,7 +32,7 @@ else
 fi
 
 if [ -z "$sublime_host" ]; then
-  sublime_host=localhost
+  sublime_host="http://localhost"
 fi
 
 SUBLIME_ENV_FILE=sublime.env
@@ -71,22 +71,22 @@ if ! grep "AWS_SECRET_ACCESS_KEY" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
 fi
 
 if ! grep "CORS_ALLOW_ORIGINS" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
-    echo "CORS_ALLOW_ORIGINS=http://$sublime_host:3000" >> $SUBLIME_ENV_FILE
+    echo "CORS_ALLOW_ORIGINS=$sublime_host:3000" >> $SUBLIME_ENV_FILE
     echo "Configured CORS allow origins"
 fi
 
 if ! grep "BASE_URL" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
-    echo "BASE_URL=http://$sublime_host:8000" >> $SUBLIME_ENV_FILE
+    echo "BASE_URL=$sublime_host:8000" >> $SUBLIME_ENV_FILE
     echo "Configured base URL"
 fi
 
 if ! grep "DASHBOARD_PUBLIC_BASE_URL" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
-    echo "DASHBOARD_PUBLIC_BASE_URL=http://$sublime_host:3000" >> $SUBLIME_ENV_FILE
+    echo "DASHBOARD_PUBLIC_BASE_URL=$sublime_host:3000" >> $SUBLIME_ENV_FILE
     echo "Configured dashboard URL"
 fi
 
 if ! grep "API_PUBLIC_BASE_URL" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
-    echo "API_PUBLIC_BASE_URL=http://$sublime_host:8000" >> $SUBLIME_ENV_FILE
+    echo "API_PUBLIC_BASE_URL=$sublime_host:8000" >> $SUBLIME_ENV_FILE
     echo "Configured API URL"
 fi
 


### PR DESCRIPTION
# Context

Previously, the installation script only verified that prerequisite utilities (e.g. `docker`, `git`, etc.) were installed but didn't check their versions. This adds version checks that are specified in our README. Additionally, I've added some more helpful console messages with links when applicable.

Follow ups:
* Update README with feedback and additional troubleshooting tips

# Changes

* Updated CI to check for platform health (`postflight_checks.sh`)
* Removed opening dashboard automatically
  * `open` had potential OS compatibility issues
  * Automatically opening a browser link made for a bad experience
* Added the ability to set the Sublime host protocol
  * Sublime host default is now `http://localhost` instead of just `localhost`
* Added various status messages with helpful links
* Added warning for unsupported operating systems and versions
* Added required `git` version to be >= `2.7`
* Added required `docker` version to be >= `20.10`
* Added required `docker-compose` version to be >= `2.10`
* Added check to ensure `docker` is running

# Tests

* Verified new CI passes (uses Ubuntu)
* Performed fresh installation on an Ubuntu VM
* Ran installation script locally (Mac OS)