### PR TITLE
Add default schema to sublime host

### DIFF
--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -63,8 +63,16 @@ fi
 if [ "$interactive" == "true" ] && [ -z "$sublime_host" ]; then
     # Since this script is intended to be piped into bash, we need to explicitly read input from /dev/tty because stdin
     # is streaming the script itself
-    printf "\nPlease specify the hostname or IP address of where you're deploying Sublime\n"
+    printf "\nPlease specify the hostname or IP address of where you're deploying Sublime. If no scheme is specified then we'll default to http://\n"
     read -rp "(IP address or hostname of your VPS or VM | default: http://localhost): " sublime_host </dev/tty
+fi
+
+if [ -z "$sublime_host" ]; then
+    sublime_host="http://localhost"
+fi
+
+if [[ "$sublime_host" != http* ]]; then
+    sublime_host="http://$sublime_host"
 fi
 
 if [ -z "$clone_platform" ]; then
@@ -95,7 +103,7 @@ if ! sublime_host=$sublime_host skip_preflight=true ./launch-sublime-platform.sh
     exit 1
 fi
 
-printf "\n** Successfully installed Sublime Platform! **\n"
+printf "\n** Successfully installed Sublime Platform! **\n\n"
 dashboard_url=$(grep 'DASHBOARD_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)
 printf "It may take a couple of minutes for all services to start for the first time\n"
 echo "Please go to your Sublime Dashboard at $dashboard_url"

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -80,6 +80,7 @@ fi
 if ! which docker > /dev/null 2>&1; then
     if [ "$machine" == "linux" ]; then
         echo "docker not installed. Please install docker and retry (https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script)"
+        echo "Note: snap versions of docker are not supported. Please use the provided link above to install Docker"
         exit 1
     fi
 
@@ -130,8 +131,8 @@ if [ -z "$docker_compose_version" ]; then
     exit 1
 fi
 
-if version_lt "$(major_minor "$docker_compose_version")" "2.10"; then
-    echo "docker compose version $docker_compose_version does not meet the minimum version of 2.10. Please update docker compose and retry"
+if version_lt "$(major_minor "$docker_compose_version")" "2.4"; then
+    echo "docker compose version $docker_compose_version does not meet the minimum version of 2.4. Please update docker compose and retry"
     exit 1
 fi
 


### PR DESCRIPTION
# Context

Installation fails if you don't specify a scheme to your hostname or IP. While it is implied that you should specify the scheme we don't actually check or default to any scheme. With this change, we now default to `http://` as the scheme since Sublime installation usually happens before setting up certificates.

# Changes

* Explicitly set `$sublime_host` default
* Check if `$sublime_host` starts with `http*`
  * This should account for both `http://` and `https://`
* Minor message updates

# Tests

Manually tested some host names:

```console
❯ ./install-and-launch.sh
Running preflight checks
Successfully completed preflight checks!

Please specify the hostname or IP address of where you're deploying Sublime. If no scheme is specified then we'll default to http://
(IP address or hostname of your VPS or VM | default: http://localhost): localhost
localhost
http://localhost

sublime-platform on  hugh.install-fixes [!⇕]
❯ ./install-and-launch.sh
Running preflight checks
Successfully completed preflight checks!

Please specify the hostname or IP address of where you're deploying Sublime. If no scheme is specified then we'll default to http://
(IP address or hostname of your VPS or VM | default: http://localhost):
Before http://localhost
After http://localhost

sublime-platform on  hugh.install-fixes [!⇕] took 2s
❯ ./install-and-launch.sh
Running preflight checks
Successfully completed preflight checks!

Please specify the hostname or IP address of where you're deploying Sublime. If no scheme is specified then we'll default to http://
(IP address or hostname of your VPS or VM | default: http://localhost): 127.0.0.1
Before 127.0.0.1
After http://127.0.0.1

sublime-platform on  hugh.install-fixes [!⇕] took 7s
❯ ./install-and-launch.sh
Running preflight checks
Successfully completed preflight checks!

Please specify the hostname or IP address of where you're deploying Sublime. If no scheme is specified then we'll default to http://
(IP address or hostname of your VPS or VM | default: http://localhost): https://localhost
Before https://localhost
After https://localhost
```