### PR TITLE
Switch docker-compose hydra image to use hydra-cpu

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
       exit 0;
       "
   hydra:
-    image: sublimesec/hydra:0.1
+    image: sublimesec/hydra-cpu:0.1
     restart: unless-stopped
     networks:
       - net


### PR DESCRIPTION
Similar to #52 but for `main`. Since the prod `0.1` tag is published now, this is good to go!

[sublimesec/hydra-cpu:0.1](https://hub.docker.com/layers/sublimesec/hydra-cpu/0.1/images/sha256-625b4bbe04fa837e77b543ffcfaf1d4dc578b2b450a391f45ab06baccf860c85?context=explore)