### PR TITLE
Colorize install script

### DIFF
--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -74,7 +74,7 @@ if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platfor
     exit 1
 fi
 
-source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"; echo done
+source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"
 
 if [ "$interactive" == "true" ] && [ -z "$sublime_host" ]; then
     print_info "Configuring host..."

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -91,7 +91,7 @@ if [ "$clone_platform" == "true" ]; then
         exit 1
     fi
 
-    cd sublime-platform || { printf "${color_error}Failed to cd into sublime-platform${color_default}\n"; exit 1; }
+    cd sublime-platform || { print_error "Failed to cd into sublime-platform"; exit 1; }
 fi
 
 

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -42,10 +42,18 @@
 #
 
 : -----------------------------------------
-:  Clone Platform - default: true
+:  Branch - default: main
 : -----------------------------------------
 
-. ./utils.sh
+# By default, this script assumes that it should pull dependencies from branch `main`. If you wish to get dependencies
+# from another branch, you can specify it here.
+#
+: curl -sL https://sublimesecurity.com/install.sh | remote_branch=custom-branch bash
+#
+
+: -----------------------------------------
+:  Clone Platform - default: true
+: -----------------------------------------
 
 # By default, this script will clone the latest Sublime Platform repo and enter into it before proceeding with the rest
 # of the installation. You may want to disable this if you're running this script from within the Sublime Platform repo
@@ -54,13 +62,19 @@
 : curl -sL https://sublimesecurity.com/install.sh | clone_platform=false bash
 #
 
-if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/main/preflight_checks.sh  | bash; then
-    exit 1
-fi
-
 if [ -z "$interactive" ]; then
     interactive="true"
 fi
+
+if [ -z "$remote_branch" ]; then
+    remote_branch="main"
+fi
+
+if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/${remote_branch}/preflight_checks.sh  | bash; then
+    exit 1
+fi
+
+source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"; echo done
 
 if [ "$interactive" == "true" ] && [ -z "$sublime_host" ]; then
     print_info "Configuring host..."

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -45,6 +45,8 @@
 :  Clone Platform - default: true
 : -----------------------------------------
 
+. ./utils.sh
+
 # By default, this script will clone the latest Sublime Platform repo and enter into it before proceeding with the rest
 # of the installation. You may want to disable this if you're running this script from within the Sublime Platform repo
 # already.
@@ -61,9 +63,10 @@ if [ -z "$interactive" ]; then
 fi
 
 if [ "$interactive" == "true" ] && [ -z "$sublime_host" ]; then
+    print_info "Configuring host..."
     # Since this script is intended to be piped into bash, we need to explicitly read input from /dev/tty because stdin
     # is streaming the script itself
-    printf "\nPlease specify the hostname or IP address of where you're deploying Sublime. If no scheme is specified then we'll default to http://\n"
+    printf "Please specify the hostname or IP address of where you're deploying Sublime. If no scheme is specified then we'll default to http://\n"
     read -rp "(IP address or hostname of your VPS or VM | default: http://localhost): " sublime_host </dev/tty
 fi
 
@@ -80,22 +83,22 @@ if [ -z "$clone_platform" ]; then
 fi
 
 if [ "$clone_platform" == "true" ]; then
-    echo "Cloning Sublime Platform repo"
+    print_info "Cloning Sublime Platform repo..."
     if ! git clone --depth=1 https://github.com/sublime-security/sublime-platform.git; then
-        echo "Failed to clone Sublime Platform repo"
+        print_error "Failed to clone Sublime Platform repo"
         echo "See https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting for troubleshooting tips"
         echo "You may need to run the following command before retrying installation: rm -rf ./sublime-platform"
         exit 1
     fi
 
-    cd sublime-platform || { echo "Failed to cd into sublime-platform"; exit 1; }
+    cd sublime-platform || { printf "${color_error}Failed to cd into sublime-platform${color_default}\n"; exit 1; }
 fi
 
 
-echo "Launching Sublime Platform"
+print_info "Launching Sublime Platform..."
 # We are skipping preflight checks because we've already performed them at the start of this script
 if ! sublime_host=$sublime_host skip_preflight=true ./launch-sublime-platform.sh; then
-    echo "Failed to launch Sublime Platform"
+    print_error "Failed to launch Sublime Platform"
     echo "See https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting for troubleshooting tips"
     echo "If you'd like to reinstall Sublime then follow the steps outline in https://docs.sublimesecurity.com/docs/quickstart-docker#wipe-postgres-volume"
     echo "Afterwards, run: rm -rf ./sublime-platform"
@@ -103,7 +106,8 @@ if ! sublime_host=$sublime_host skip_preflight=true ./launch-sublime-platform.sh
     exit 1
 fi
 
-printf "\n** Successfully installed Sublime Platform! **\n\n"
+print_success "Successfully installed Sublime Platform!"
+
 dashboard_url=$(grep 'DASHBOARD_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)
 printf "It may take a couple of minutes for all services to start for the first time\n"
 echo "Please go to your Sublime Dashboard at $dashboard_url"

--- a/postflight_checks.sh
+++ b/postflight_checks.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+. ./utils.sh
+
 if ! which jq > /dev/null 2>&1; then
-    echo "Post-flight checks require jq to be installed. Please install jq and retry (https://stedolan.github.io/jq/download/)"
+    print_error "Post-flight checks require jq to be installed. Please install jq and retry (https://stedolan.github.io/jq/download/)"
     exit 1
 fi
 
@@ -22,10 +24,10 @@ remaining_unhealthy_retries=$unhealthy_retries
 
 health_endpoint="$(grep 'API_PUBLIC_BASE_URL' sublime.env | cut -d'=' -f2)/v1/health"
 while [ $remaining_timeout_seconds -gt 0 ]; do
-    echo "Attempting to check Sublime Platform health"
+    print_info "Attempting to check Sublime Platform health"
 
     if [ "$(curl -s "$health_endpoint" | jq '.success')" == "true" ]; then
-        echo "Sublime Platform is healthy!"
+        print_success "Sublime Platform is healthy!"
         exit 0
     fi
 
@@ -34,7 +36,7 @@ while [ $remaining_timeout_seconds -gt 0 ]; do
     fi
 
     if [ $remaining_unhealthy_retries -lt 0 ]; then
-        echo "Sublime Platform is unhealthy. See details below:"
+        print_error "Sublime Platform is unhealthy. See details below:"
         curl -s "$health_endpoint" | jq '.'
         exit 1
     fi
@@ -43,5 +45,5 @@ while [ $remaining_timeout_seconds -gt 0 ]; do
     sleep $retry_interval_seconds
 done
 
-echo "Unable to check Sublime Platform health due to timeout"
+print_error "Unable to check Sublime Platform health due to timeout"
 exit 1

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -5,9 +5,9 @@ if [ "$skip_preflight" == "true" ]; then
     exit 0
 fi
 
-print_info "Running preflight checks..."
-
 source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"; echo done
+
+print_info "Running preflight checks..."
 
 major_minor() {
   echo "${1%%.*}.$(

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+. ./utils.sh
+
 # shellcheck disable=SC2154
 if [ "$skip_preflight" == "true" ]; then
     exit 0
 fi
 
-echo "Running preflight checks"
+print_info "Running preflight checks..."
 
 major_minor() {
   echo "${1%%.*}.$(
@@ -32,13 +34,13 @@ case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
 esac
 
 if [ -z "$machine" ]; then
-    echo "Warning: You are using a non-recommended operating system so subsequent failures may occur"
+    print_warning "Warning: You are using a non-recommended operating system so subsequent failures may occur"
 fi
 
 if [ "$machine" == "macos" ]; then
     macos_version="$(/usr/bin/sw_vers -productVersion)"
     if version_lt "$(major_minor "$macos_version")" "11.0"; then
-        echo "Warning: Mac OS version $macos_version does not meet the recommended minimum version of 11.0"
+        print_warning "Warning: Mac OS version $macos_version does not meet the recommended minimum version of 11.0"
     fi
 fi
 
@@ -49,15 +51,15 @@ if [ "$machine" == "linux" ]; then
         # "Release:    18.04" -> "18.04"
         ubuntu_version="$(lsb_release -a 2>/dev/null | grep 'Release' | cut -d':' -f2 | xargs)"
         if version_lt "$ubuntu_version" "20.04"; then
-            echo "Warning: Ubuntu version $ubuntu_version does not meet the recommended minimum version of 20.04"
+            print_warning "Warning: Ubuntu version $ubuntu_version does not meet the recommended minimum version of 20.04"
         fi
     else
-        echo "Warning: Non-Ubuntu Linux distributions are unsupported and subsequent failures may occur"
+        print_warning "Warning: Non-Ubuntu Linux distributions are unsupported and subsequent failures may occur"
     fi
 fi
 
 if ! which git > /dev/null 2>&1; then
-    echo "git not installed. Please install git and retry (https://git-scm.com/downloads)"
+    print_error "git not installed. Please install git and retry (https://git-scm.com/downloads)"
     exit 1
 fi
 
@@ -73,18 +75,18 @@ git_version=${git_version##*version }
 git_version=${git_version%% (*}
 
 if version_lt "$(major_minor "$git_version")" "2.7"; then
-    echo "git version $git_version does not meet the minimum version of 2.7. Please update git and retry"
+    print_error "git version $git_version does not meet the minimum version of 2.7. Please update git and retry"
     exit 1
 fi
 
 if ! which docker > /dev/null 2>&1; then
     if [ "$machine" == "linux" ]; then
-        echo "docker not installed. Please install docker and retry (https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script)"
+        print_error "docker not installed. Please install docker and retry (https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script)"
         echo "Note: snap versions of docker are not supported. Please use the provided link above to install Docker"
         exit 1
     fi
 
-    echo "docker not installed. Please install docker and retry (https://docs.docker.com/get-docker/)"
+    print_error "docker not installed. Please install docker and retry (https://docs.docker.com/get-docker/)"
     exit 1
 fi
 
@@ -105,12 +107,12 @@ docker_version=${docker_version##*version }
 docker_version=${docker_version%%, *}
 
 if version_lt "$(major_minor "$docker_version")" "20.10"; then
-    echo "docker version $docker_version does not meet the minimum version of 20.10. Please update docker and retry"
+    print_error "docker version $docker_version does not meet the minimum version of 20.10. Please update docker and retry"
     exit 1
 fi
 
 if ! $docker_cmd_prefix docker info > /dev/null 2>&1; then
-	echo "docker is not running. Please start docker and retry"
+	print_error "docker is not running. Please start docker and retry"
 	exit 1
 fi
 

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-. ./utils.sh
-
 # shellcheck disable=SC2154
 if [ "$skip_preflight" == "true" ]; then
     exit 0
 fi
 
 print_info "Running preflight checks..."
+
+source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"; echo done
 
 major_minor() {
   echo "${1%%.*}.$(

--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -5,7 +5,7 @@ if [ "$skip_preflight" == "true" ]; then
     exit 0
 fi
 
-source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"; echo done
+source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"
 
 print_info "Running preflight checks..."
 

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -3,6 +3,8 @@
 
 cmd_prefix="sudo "
 
+. ./utils.sh
+
 # Docker setups on OS X generally won't need sudo
 # TODO this check is pretty naive -- a properly setup docker/compose setup in Linux won't need sudo either
 case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
@@ -12,7 +14,7 @@ esac
 
 if [[ "$1" != "always_launch" ]]; then
     if ! $cmd_prefix docker compose ps | grep "mantis" > /dev/null 2>&1; then
-        echo "docker compose appears to be brought down. Will not proceed to avoid relaunching."
+        print_error "docker compose appears to be brought down. Will not proceed to avoid relaunching."
         exit 0
     fi
 fi
@@ -28,7 +30,7 @@ if [[ -z "$(git status --porcelain)" ]]; then
             $cmd_prefix docker compose down --remove-orphans
 	fi
 else
-    echo "Uncommitted changes present, ignoring updates to sublime-platform git repo"
+    print_warning "Uncommitted changes present, ignoring updates to sublime-platform git repo"
 fi
 
 if [ -z "$sublime_host" ]; then

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+: ==========================================
+:   Installation utilities
+: ==========================================
+
+# This file contains utility functions to be used within the
+# Sublime installation scripts.
+
+color_default="0m"
+color_info="96m"
+color_success="92m"
+color_warning="93m"
+color_error="91m"
+
+# prints colored text
+print_color() {
+    if [ "$2" == "info" ] ; then
+        COLOR="$color_info"
+    elif [ "$2" == "success" ] ; then
+        COLOR="$color_success"
+    elif [ "$2" == "warning" ] ; then
+        COLOR="$color_warning"
+    elif [ "$2" == "error" ] ; then
+        COLOR="$color_error"
+    else #default color
+        COLOR="$color_default"
+    fi
+
+    STARTCOLOR="\e[$COLOR"
+    ENDCOLOR="\e[$color_default"
+
+    printf "${STARTCOLOR}%b${ENDCOLOR}" "$1"
+}
+
+print_error() {
+   print_color "\n$1\n" "error"
+}
+
+print_success() {
+   printf "\n** "
+   print_color "$1" "success"
+   printf " **\n"
+}
+
+print_info() {
+   print_color "\n$1\n" "info"
+}
+
+print_warning() {
+   print_color "\n$1\n" "warning"
+}


### PR DESCRIPTION
This PR colorizes the install scripts for a little more visual flair. Additionally, a `remote_branch` command-line option was added to aid in testing.

**To test**: `curl https://raw.githubusercontent.com/sublime-security/sublime-platform/7369df49e42cf1d5b65396393f31eaeba667523e/install-and-launch.sh | remote_branch=7369df49e42cf1d5b65396393f31eaeba667523e bash`

**Screenshots**
<img width="999" alt="image" src="https://user-images.githubusercontent.com/611653/211639279-dfa25ad6-c0c6-4560-8dec-ac7aa7e53a5a.png">

<img width="971" alt="image" src="https://user-images.githubusercontent.com/611653/211633494-26485112-dda8-46ff-8510-d763e24a2241.png">

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/611653/211639020-bdc2d271-e9d0-4a2e-a7c0-bf4b819052d3.png">

<img width="656" alt="image" src="https://user-images.githubusercontent.com/611653/211634999-9a43e6bb-8e2f-475d-acce-02eaa6344ab8.png">

