### PR TITLE
Move auto-updates prompt closer to permission dialogue

### DIFF
--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -101,26 +101,6 @@ if [ "$interactive" == "true" ] && [ -z "$sublime_host" ]; then
     read -rp "(IP address or hostname of your VPS or VM | default: http://localhost): " sublime_host </dev/tty
 fi
 
-if [ "$interactive" == "true" ] && [ -z "$auto_updates" ]; then
-    print_info "Configuring automatic updates..."
-
-    while true; do
-        # Since this script is intended to be piped into bash, we need to explicitly read input from /dev/tty because stdin
-        # is streaming the script itself
-        read -rp "Would you like to enable auto-updates? If yes, your terminal may request permissions to make updates to your computer: [Y/n]: " yn </dev/tty
-        case $yn in
-            [Yy]* ) auto_updates="true"; break;;
-            [Nn]* ) auto_updates="false"; break;;
-            * ) echo "Please answer y or n.";;
-        esac
-    done
-
-    # Re-run preflight checks with auto_update flag configured
-    if ! curl -sL https://raw.githubusercontent.com/sublime-security/sublime-platform/${remote_branch}/preflight_checks.sh | auto_updates=$auto_updates bash; then
-        exit 1
-    fi
-fi
-
 if [ -z "$sublime_host" ]; then
     sublime_host="http://localhost"
 fi
@@ -145,10 +125,8 @@ if [ "$clone_platform" == "true" ]; then
     cd sublime-platform || { print_error "Failed to cd into sublime-platform"; exit 1; }
 fi
 
-
-print_info "Launching Sublime Platform..."
 # We are skipping preflight checks because we've already performed them at the start of this script
-if ! sublime_host=$sublime_host skip_preflight=true auto_updates=$auto_updates ./launch-sublime-platform.sh; then
+if ! sublime_host=$sublime_host skip_preflight=true interactive=$interactive auto_updates=$auto_updates ./launch-sublime-platform.sh; then
     print_error "Failed to launch Sublime Platform"
     echo "See https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting for troubleshooting tips"
     echo "If you'd like to reinstall Sublime then follow the steps outline in https://docs.sublimesecurity.com/docs/quickstart-docker#wipe-postgres-volume"


### PR DESCRIPTION
# Context

Follow up to https://github.com/sublime-security/sublime-platform/pull/59. This moves the prompt for automatic updates closer to when it actually gets set. In the original PR, you have to wait until after the repo clone to get prompted for cron accessibility permissions but the delay can cause confusions.

I also made the prompt default to true if the user doesn't input anything.

## Before

![image](https://user-images.githubusercontent.com/112737708/213749800-7fe92802-a381-4eae-ba94-b464e3a52846.png)

## After

![Screenshot 2023-01-20 at 8 11 36 AM](https://user-images.githubusercontent.com/112737708/213749644-91c2059b-8455-4af5-a9fb-e789ff30bd17.png)
