### PR TITLE
Nicer output for docker compose pull

### DIFF
--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -92,5 +92,5 @@ if ! grep "API_PUBLIC_BASE_URL" $SUBLIME_ENV_FILE > /dev/null 2>&1; then
     echo "Configured API URL"
 fi
 
-$cmd_prefix docker compose pull && $cmd_prefix docker compose up -d
+$cmd_prefix docker compose up --quiet-pull -d
 


### PR DESCRIPTION
I *think* this should be functionally equivalent, but please correct me if that's not right.

The terminal output for `docker compose pull` was way too crazy, and `docker compose pull -q` showed __no output__ at all.

If this is functionally equivalent, it looks like a nice middle ground.

Before:
![2023-01-22 21 19 56](https://user-images.githubusercontent.com/11003450/213956185-52168719-972b-4021-9d2b-1e2979600c85.gif)

After:
![2023-01-22 21 20 11](https://user-images.githubusercontent.com/11003450/213955970-5f7cf023-a176-4c8e-ab92-cd3ee1817b7e.gif)

