### PR TITLE
Add default remote branch to preflight script

### DIFF
--- a/preflight_checks.sh
+++ b/preflight_checks.sh
@@ -5,6 +5,10 @@ if [ "$skip_preflight" == "true" ]; then
     exit 0
 fi
 
+if [ -z "$remote_branch" ]; then
+    remote_branch="main"
+fi
+
 source /dev/stdin <<< "$(curl -sL https://raw.github.com/sublime-security/sublime-platform/${remote_branch}/utils.sh)"
 
 print_info "Running preflight checks..."


### PR DESCRIPTION
Verified that the following command now works:

```
interactive=false ./launch-sublime-platform.sh
```

Will need to update the CI script accordingly.