### PR TITLE
Add interactive prompt for ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+certbot.env
 sublime.env
 *.swp

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -431,14 +431,34 @@ launch_sublime() {
 }
 
 install_sublime() {
+    if [ -z "$clone_platform" ]; then
+        clone_platform=true
+    fi
+
+    if [ "$clone_platform" = "true" ]; then
+        print_info "Cloning Sublime Platform repo..."
+        if ! git clone --depth=1 https://github.com/sublime-security/sublime-platform.git; then
+            print_error "Failed to clone Sublime Platform repo\n"
+            printf "Troubleshooting tips: https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting\n\n"
+            printf "You may need to run the following command before retrying installation:\n\n"
+            printf "rm -rf ./sublime-platform\n"
+            exit 1
+        fi
+
+        cd sublime-platform || {
+            print_error "Failed to cd into sublime-platform"
+            exit 1
+        }
+    fi
+
     if [ "$interactive" = "true" ] && [ ! -f "$CERTBOT_ENV_FILE" ]; then
-        printf "\nWill your installation use SSL? (y|n) "
+        printf "\nWill your installation use SSL? (y/n) "
         read -r enable_ssl </dev/tty
     fi
 
     if [ "$enable_ssl" = "y" ]; then
-        print_color "\nYou will need to perform some manual steps in order to enable SSL. Please follow the" info
-        print_info "instructions at https://docs.sublimesecurity.com/todo and re-run the script to finish installation.\n" info
+        print_color "\nYou will need to perform some manual steps in order to enable SSL. Please follow the instructions" info
+        print_info "at https://docs.sublimesecurity.com/docs/quickstart-docker#ssl and re-run the script to finish installation.\n" info
         exit 0
     fi
 
@@ -472,26 +492,6 @@ install_sublime() {
     *) sublime_host="http://$sublime_host" ;;
     esac
 
-    if [ -z "$clone_platform" ]; then
-        clone_platform=true
-    fi
-
-    if [ "$clone_platform" = "true" ]; then
-        print_info "Cloning Sublime Platform repo..."
-        if ! git clone --depth=1 https://github.com/sublime-security/sublime-platform.git; then
-            print_error "Failed to clone Sublime Platform repo\n"
-            printf "Troubleshooting tips: https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting\n\n"
-            printf "You may need to run the following command before retrying installation:\n\n"
-            printf "rm -rf ./sublime-platform\n"
-            exit 1
-        fi
-
-        cd sublime-platform || {
-            print_error "Failed to cd into sublime-platform"
-            exit 1
-        }
-    fi
-
     if ! launch_sublime "$sublime_host"; then
         print_error "Failed to launch Sublime Platform\n"
         printf "Troubleshooting tips: https://docs.sublimesecurity.com/docs/quickstart-docker#troubleshooting\n\n"
@@ -500,7 +500,6 @@ install_sublime() {
         printf "You can then go through the Sublime Platform installation again\n"
         exit 1
     fi
-
 }
 
 health_check() {

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -462,7 +462,7 @@ install_sublime() {
         exit 0
     fi
 
-    if [ "$interactive" = "true" ] && [ -z "$sublime_host" ]; then
+    if [ "$interactive" = "true" ] && [ -z "$sublime_host" ] && [ ! -f "$CERTBOT_ENV_FILE" ]; then
         print_info "Configuring host...\n"
 
         # showing 'http://localhost' as the default can be confusing if you're on a remote host

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -460,6 +460,8 @@ install_sublime() {
         print_color "\nYou will need to perform some manual steps in order to enable SSL. Please follow the instructions" info
         print_info "at https://docs.sublimesecurity.com/docs/quickstart-docker#ssl and re-run this script to finish setup.\n" info
         exit 0
+    else
+        print_success "** SSL is configured **"
     fi
 
     if [ "$interactive" = "true" ] && [ -z "$sublime_host" ] && [ ! -f "$CERTBOT_ENV_FILE" ]; then

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -452,13 +452,13 @@ install_sublime() {
     fi
 
     if [ "$interactive" = "true" ] && [ ! -f "$CERTBOT_ENV_FILE" ]; then
-        printf "\nWill your installation use SSL? (y/n) "
+        printf "\nWould you like to setup SSL with LetsEncrypt? You must have a custom domain. (y/N): "
         read -r enable_ssl </dev/tty
     fi
 
-    if [ "$enable_ssl" = "y" ]; then
+    if [ "$enable_ssl" = "y" ] || [ "$enable_ssl" = "Y" ] || [ "$enable_ssl" = "yes" ]; then
         print_color "\nYou will need to perform some manual steps in order to enable SSL. Please follow the instructions" info
-        print_info "at https://docs.sublimesecurity.com/docs/quickstart-docker#ssl and re-run the script to finish installation.\n" info
+        print_info "at https://docs.sublimesecurity.com/docs/quickstart-docker#ssl and re-run this script to finish setup.\n" info
         exit 0
     fi
 

--- a/install-and-launch.sh
+++ b/install-and-launch.sh
@@ -194,6 +194,8 @@ if [ "$interactive" != "true" ] && [ -z "$auto_updates" ]; then
     auto_updates=true
 fi
 
+CERTBOT_ENV_FILE=certbot.env
+
 default_host="http://localhost"
 
 preflight_checks() {
@@ -429,6 +431,17 @@ launch_sublime() {
 }
 
 install_sublime() {
+    if [ "$interactive" = "true" ] && [ ! -f "$CERTBOT_ENV_FILE" ]; then
+        printf "\nWill your installation use SSL? (y|n) "
+        read -r enable_ssl </dev/tty
+    fi
+
+    if [ "$enable_ssl" = "y" ]; then
+        print_color "\nYou will need to perform some manual steps in order to enable SSL. Please follow the" info
+        print_info "instructions at https://docs.sublimesecurity.com/todo and re-run the script to finish installation.\n" info
+        exit 0
+    fi
+
     if [ "$interactive" = "true" ] && [ -z "$sublime_host" ]; then
         print_info "Configuring host...\n"
 

--- a/sublime.env.example
+++ b/sublime.env.example
@@ -1,0 +1,4 @@
+CORS_ALLOW_ORIGINS=http://localhost:3000
+BASE_URL=http://localhost:8000
+DASHBOARD_PUBLIC_BASE_URL=http://localhost:3000
+API_PUBLIC_BASE_URL=http://localhost:8000

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -94,7 +94,8 @@ if ! grep "API_PUBLIC_BASE_URL" $SUBLIME_ENV_FILE >/dev/null 2>&1; then
 fi
 
 if [ -f "$CERTBOT_ENV_FILE" ]; then
-    $cmd_prefix LETSENCRYPT_ENV="$CERTBOT_ENV_FILE" docker compose --profile letsencrypt up --quiet-pull -d
+    export LETSENCRYPT_ENV="$CERTBOT_ENV_FILE"
+    $cmd_prefix docker compose --profile letsencrypt up --quiet-pull -d
 else
     $cmd_prefix docker compose up --quiet-pull -d
 fi


### PR DESCRIPTION
Adds low(er)-risk interactive prompt for SSL support. Suggested doc edits have been submitted separately.

**NOTE**: We'll need one additional step in the docs (and I'm unable to add it because the 'suggest additional edits' button does not work): if `sublime.env` does not exist, then `cp sublime.env.example sublime.env`. This is to occur before "Update sublime.env with your domain..."

**Flow for new users:**
1. Run `curl -sL https://sublimesecurity.com/install.sh | sh`
2. Select `y` for SSL (exits script, redirects to docs).
3. Go to docs.
4. Configure domain.
5. Edit `sublime.env` and `certbot.env` in `sublime-platform` directory
6. Re-run script from `sublime-platform` directory: `clone_platform=false ./install-and-launch.sh` (doesn't prompt for SSL because `certbot.env` exists.


**Flow for existing users:**
1. Read docs
2. Configure domain.
3. Edit `sublime.env` and `certbot.env` in `sublime-platform` directory
4. Re-run script from `sublime-platform` directory: `clone_platform=false ./install-and-launch.sh` ... or run `./update-and-run.sh always_launch` ... or run `LETSENCRYPT_ENV=certbot.env docker compose --profile letsencrypt  up -d` ... 😬 

<img width="795" alt="image" src="https://user-images.githubusercontent.com/611653/220008278-52f3d44e-dd05-4808-a29f-1ab3399e178a.png">