### PR TITLE
Pull images before doing docker compose up

### DIFF
--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -93,8 +93,10 @@ if ! grep "API_PUBLIC_BASE_URL" $SUBLIME_ENV_FILE >/dev/null 2>&1; then
     echo "Configured API URL"
 fi
 
+$cmd_prefix docker compose pull --include-deps
+
 if [ -f "$CERTBOT_ENV_FILE" ]; then
-    $cmd_prefix sudo sh -c "LETSENCRYPT_ENV=$CERTBOT_ENV_FILE docker compose --profile letsencrypt up --quiet-pull -d"
+    $cmd_prefix sh -c "LETSENCRYPT_ENV=$CERTBOT_ENV_FILE docker compose --profile letsencrypt up --quiet-pull -d"
 else
     $cmd_prefix docker compose up --quiet-pull -d
 fi


### PR DESCRIPTION
This pulls Docker images before doing a `docker compose up` so we don't have stale images.

Tested with DO and made the changes manually to the `update-and-run.sh` to verify it still works.