### PR TITLE
Scale strelka backends to 2 by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,9 +93,10 @@ services:
     volumes:
       - ./configs/frontend/:/etc/strelka/:ro
       - logs:/var/log/strelka/
-    container_name: sublime_strelka_frontend_1
     depends_on:
       - sublime_strelka_coordinator
+    deploy:
+      replicas: 1
   sublime_strelka_backend:
     image: sublimesec/strelka-backend:0.3
     restart: unless-stopped
@@ -105,9 +106,10 @@ services:
       - net
     volumes:
       - ./configs/backend/:/etc/strelka/:ro
-    container_name: sublime_strelka_backend_1
     depends_on:
       - sublime_strelka_coordinator
+    deploy:
+      replicas: 2
   sublime_strelka_manager:
     image: sublimesec/strelka-manager:0.3
     restart: unless-stopped


### PR DESCRIPTION
TIL docker-compose can automatically scale, so we can specify in the compose file how many to create. To scale it further: `docker-compose up -d --scale sublime_strelka_backend=4`

We can also consider adding bora scalers this way. Naturally, AWS will do all of this better, but this will mean more mileage and flexibility for Docker deployments.

<!-- Task: https://www.notion.so/sublimesecurity/82cf45d1d1da4e078e4ce5904e4bcf1d -->