### PR TITLE
Allow overriding cmd prefix

### DIFF
--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -12,6 +12,10 @@ linux*) cmd_prefix="sudo " ;;
 darwin*) cmd_prefix="" ;;
 esac
 
+if [ -z "$cmd_prefix_override" ]; then
+    cmd_prefix=$cmd_prefix_override
+fi
+
 if [ "$1" != "always_launch" ]; then
     if ! $cmd_prefix docker compose ps | grep "mantis" >/dev/null 2>&1; then
         print_error "docker compose appears to be brought down. Will not proceed to avoid relaunching."

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -12,7 +12,7 @@ linux*) cmd_prefix="sudo " ;;
 darwin*) cmd_prefix="" ;;
 esac
 
-if [ -z "$cmd_prefix_override" ]; then
+if [ ! -z "$cmd_prefix_override" ]; then
     cmd_prefix=$cmd_prefix_override
 fi
 


### PR DESCRIPTION
Running the setup script in a GHA environment generally works -- the `sudo` prefix is used and doesn't cause problems (Ubuntu GHA runner so it's recognized as linux). However, if a private repo is used to add/replace a service then using sudo prevents the credentials which were associated via `docker login`.

This is a super simple approach and isn't added to docs/general usage. This use case is kind of specific to some internal testing -- there's not really a reason for a customer to need compatibility with `docker login` since all of our images are public.