### PR TITLE
Increase the HTTP max request body size

### DIFF
--- a/nginx-letsencrypt/nginx.conf
+++ b/nginx-letsencrypt/nginx.conf
@@ -9,6 +9,8 @@ http {
 		'' close;
 	}
 
+	client_max_body_size 50M;
+	
 	server {
 		listen 80;
 		server_name ___server_names___;


### PR DESCRIPTION
[Community slack thread](https://sublimecommunity.slack.com/archives/C01QMCMRJ56/p1704378224881139)

TBD what the sweet spot is, but the 2M default is definitely too low. A high number could mean higher memory and possibly an easier DoS if Docker is opened up to the internet (but then again, that's already possible by flooding requests, so maybe moot).