### PR TITLE
feat: add mantis host url to FE container in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,8 @@ services:
     networks:
       - net
     env_file: sublime.env
+    environment:
+      MANTIS_HOST_URL: "http://sublime_mantis:8000"
     depends_on:
       - sublime_mantis
   sublime_redis:


### PR DESCRIPTION
This allows us to make requests from the dashboard container's server to Mantis. `BASE_URL` doesn't work on the server since it's a `localhost` URL meant to be hit from the user's browser, so we need the `http:sublime_mantis:8000` URL.

This env variable is not required for the app to function, and is currently only set here in `docker-compose`.