### PR TITLE
Increase Hydra default timeout to 30s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,8 @@ services:
     networks:
       - net
     container_name: sublime_hydra
+    environment:
+      HYDRA_CLIENT_TIMEOUT_OVERRIDE_SEC: 30
   sublime_nginx_letsencrypt:
     image: sublimesec/nginx-letsencrypt:latest
     restart: unless-stopped


### PR DESCRIPTION
This increases the default timeout for Hydra from 10s to 30s. This is particularly relevant for GPU functions, like `logo-detect` which can take over 10s for certain attachments on `hydra-cpu`

<!-- https://www.notion.so/sublimesecurity/cfcaabe2132244f28537e67ac9fa989e?pvs=4 -->