### PR TITLE
Remove inline-messages bucket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,6 @@ services:
       sleep 15;
       /usr/bin/mc config host add myminio http://sublimes3:8110 $$AWS_ACCESS_KEY_ID $$AWS_SECRET_ACCESS_KEY;
       /usr/bin/mc mb myminio/email-screenshots;
-      /usr/bin/mc mb myminio/inline-messages;
       /usr/bin/mc ls myminio;
       exit 0;
       "


### PR DESCRIPTION
Notion: https://www.notion.so/sublimesecurity/Remove-inline-messages-S3-bucket-a3ee96e4bcba499aa539f685f5165910?pvs=4

No longer used.