### PR TITLE
Freeze Hydra web concurrency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,7 @@ services:
     container_name: sublime_hydra
     environment:
       WORKERS: 1
+      WEB_CONCURRENCY: 5
   sublime_nginx_letsencrypt:
     image: sublimesec/nginx-letsencrypt:latest
     restart: unless-stopped


### PR DESCRIPTION
# Context

This explicitly sets `WEB_CONCURRENCY` to what is currently set in Docker so Docker deployments in the future won't be affected by non-Docker deployment changes. This should ultimately be a no-op.