### PR TITLE
Freeze Hydra timeouts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,8 @@ services:
     environment:
       WORKERS: 1
       WEB_CONCURRENCY: 5
+      WORKER_TIMEOUT: 30
+      GRACEFUL_WORKER_TIMEOUT: 30
   sublime_nginx_letsencrypt:
     image: sublimesec/nginx-letsencrypt:latest
     restart: unless-stopped


### PR DESCRIPTION
# Context

This freezes Hydra timeouts to 30 seconds which is what is currently set in the Dockerfile. These timeout values are only really applicable to Docker compose deployments so this limits the timeout values to the necessary environments. This ensures we can experiment with different Hydra timeouts without causing issues for Docker compose deployments.