### PR TITLE
Freeze Hydra keep-alive at 2 seconds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,7 @@ services:
     environment:
       WORKERS: 1
       WEB_CONCURRENCY: 5
+      KEEP_ALIVE: 2
       WORKER_TIMEOUT: 30
       GRACEFUL_WORKER_TIMEOUT: 30
   sublime_nginx_letsencrypt:


### PR DESCRIPTION
This is what is currently set in the Hydra Docker image so this will be a no-op. We should keep this low when Hydra isn't behind a load balancer (e.g. Docker Compose deployments).