### PR TITLE
Remove S3/MinIO config for screenshot service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,16 +143,10 @@ services:
     image: sublimesec/render-email-html:0.1
     restart: unless-stopped
     environment:
-      - S3_ENDPOINT=http://sublimes3:8110
-      - SCREENSHOT_BUCKET=email-screenshots
-      - AWS_REGION=us-east-1
       - DISABLE_DD=true
     container_name: sublime_screenshot_service
-    env_file: sublime.env
     networks:
       - net
-    depends_on:
-      - sublime_create_buckets
   # Keep this name as sublimes3 because underscores don't play nice with certain endpoint validation
   sublimes3:
     container_name: sublimes3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
     networks:
       - net
   sublime_screenshot_service:
-    image: sublimesec/render-email-html:0.1
+    image: sublimesec/render-email-html:0.2
     restart: unless-stopped
     environment:
       - DISABLE_DD=true


### PR DESCRIPTION
No longer needed (the screenshot is always returned in this context). Removing these env vars would be compatibly with all recent `0.1` versions of `sublimesec/render-email-html`, but I'm following standard procedure and bumping to `0.2` to prevent any issues for anyone with very stale versions of `sublimesec/render-email-html`.