### PR TITLE
Upgrade all GHA from Ubuntu 20.04 to latest.

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   tests:
     name: Validate Platform Installation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Ubuntu 20.04 will be EOL shortly and discontinued by GitHub Actions.

https://www.notion.so/sublimesecurity/GitHub-Actions-Ubuntu-20-04-sunset-1a004655fc9d8018b776c64b47f12cf1?pvs=4

https://github.com/actions/runner-images/issues/11101