### PR TITLE
Update `sublime_create_buckets` command to use `alias`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 15;
-      /usr/bin/mc config host add myminio http://sublimes3:8110 $$AWS_ACCESS_KEY_ID $$AWS_SECRET_ACCESS_KEY;
+      /usr/bin/mc alias set myminio http://sublimes3:8110 $$AWS_ACCESS_KEY_ID $$AWS_SECRET_ACCESS_KEY;
       /usr/bin/mc mb myminio/email-screenshots;
       /usr/bin/mc mb myminio/events;
       /usr/bin/mc mb myminio/message-storage;


### PR DESCRIPTION
The `config` command is deprecated and removed in a recent release of `mc`. This PR updates the command to use the recommended `alias` command instead.