### PR TITLE
Nit: Fix indentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       PGDATA: /data/postgres
     env_file: sublime.env
     volumes:
-       - postgres:/data/postgres
+      - postgres:/data/postgres
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
Fix the indentation on line 12 in `docker-compose.yml`.

```
$ yamllint docker-compose.yml 
  1:1       warning  missing document start "---"  (document-start)
  12:8      error    wrong indentation: expected 6 but found 7  (indentation)
  99:81     error    line too long (100 > 80 characters)  (line-length)
  127:81    error    line too long (102 > 80 characters)  (line-length)
```