### PR TITLE
nit: fix indentation in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - sublime_strelka_backend
       - sublime_strelka_frontend
     volumes:
-       - persistent_storage:/data/persistent_storage
+      - persistent_storage:/data/persistent_storage
   sublime_bora_lite:
     image: sublimesec/bora-lite:1.69
     restart: unless-stopped
@@ -58,7 +58,7 @@ services:
       - sublime_strelka_backend
       - sublime_strelka_frontend
     volumes:
-       - persistent_storage:/data/persistent_storage
+      - persistent_storage:/data/persistent_storage
   sublime_postgres:
     image: postgres:13.2
     command: -c 'max_connections=200'
@@ -70,7 +70,7 @@ services:
       PGDATA: /data/postgres
     env_file: sublime.env
     volumes:
-       - postgres:/data/postgres
+      - postgres:/data/postgres
     networks:
       - net
   sublime_dashboard:


### PR DESCRIPTION
Fix the indentation in the `docker-compose.yml` file.

```
$ yamllint docker-compose.yml 
docker-compose.yml
  1:1       warning  missing document start "---"  (document-start)
  12:81     error    line too long (81 > 80 characters)  (line-length)
  32:8      error    wrong indentation: expected 6 but found 7  (indentation)
  43:81     error    line too long (81 > 80 characters)  (line-length)
  61:8      error    wrong indentation: expected 6 but found 7  (indentation)
  73:8      error    wrong indentation: expected 6 but found 7  (indentation)
  148:81    error    line too long (100 > 80 characters)  (line-length)
  174:81    error    line too long (102 > 80 characters)  (line-length)
```