### PR TITLE
Docker Compose: Spin up Azurite Container for testing Mantis Integration

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   tests:
     name: Validate Platform Installation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,34 @@ services:
       - net
     depends_on:
       - sublime_create_buckets
+  sublime_azurite:
+      container_name: sublime_azurite
+      image: mcr.microsoft.com/azure-storage/azurite
+      restart: unless-stopped
+      networks:
+        - net
+      ports:
+        - "10000:10000"  # Blob service
+        - "10001:10001"  # Queue service
+        - "10002:10002"  # Table service
+      volumes:
+        - azurite_data:/data
+      command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --location /data --skipApiVersionCheck
+  sublime_create_azure_blob_containers:
+    image: mcr.microsoft.com/azure-cli
+    depends_on:
+      - sublime_azurite
+    networks:
+      - net
+    environment:
+      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://sublime_azurite:10000/devstoreaccount1;"
+    command: >
+      bash -c "
+      az storage container create --name email-screenshots &&
+      az storage container create --name events &&
+      az storage container create --name message-storage &&
+      az storage container create --name message-export
+      "
   # Keep this name as sublimes3 because underscores don't play nice with certain endpoint validation
   sublimes3:
     container_name: sublimes3
@@ -166,3 +194,4 @@ volumes:
   logs:
   s3_data:
   localstack:
+  azurite_data:


### PR DESCRIPTION
The purpose of this is to make it easier for developers to verify that their changes are compatible with Azure blob storage. With this change, developers will simply need to add

```
azure:
  blob_storage:
    endpoint: http://127.0.0.1:10000/devstoreaccount1
```
to their config.yaml