### PR TITLE
Update nginx to the latest and improve TLS cipher suite list. TASK-55769

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Sublime Security
+Copyright (c) 2021-2026 Sublime Security
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/nginx-custom-ssl/Dockerfile
+++ b/nginx-custom-ssl/Dockerfile
@@ -5,6 +5,5 @@ COPY conf/ssl-params.conf /etc/nginx/ssl-params.conf
 
 COPY certs/nginx.crt /etc/ssl/certs/nginx.crt
 COPY certs/nginx.key /etc/ssl/private/nginx.key
-COPY certs/dhparam.pem /etc/ssl/certs/dhparam.pem
 
 CMD nginx -g "daemon off;"

--- a/nginx-custom-ssl/Dockerfile
+++ b/nginx-custom-ssl/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.23.3
+FROM nginx:1.30.0
 
 COPY conf/nginx.conf /etc/nginx/nginx.conf
 COPY conf/ssl-params.conf /etc/nginx/ssl-params.conf

--- a/nginx-custom-ssl/README.md
+++ b/nginx-custom-ssl/README.md
@@ -5,8 +5,8 @@ SSL support with custom cert.
 To enable SSL with your custom certificate, follow the steps below:
 
 1. Copy your certificate and key to certs/nginx.crt and certs/nginx.key
-3. Edit conf/nginx.conf to update `__server_names__` to your domain or IP address
-4. Perform any other configuration edits that you might need
-5. Run `docker build -t sublime_nginx_custom_ssl .`
-6. Run `cd ..` (back to sublime-platform directory)
-7. Run `docker compose --profile nginx-custom-ssl up`
+2. Edit conf/nginx.conf to update `__server_names__` to your domain or IP address
+3. Perform any other configuration edits that you might need
+4. Run `docker build -t sublime_nginx_custom_ssl .`
+5. Run `cd ..` (back to sublime-platform directory)
+6. Run `docker compose --profile nginx-custom-ssl up`

--- a/nginx-custom-ssl/README.md
+++ b/nginx-custom-ssl/README.md
@@ -5,7 +5,6 @@ SSL support with custom cert.
 To enable SSL with your custom certificate, follow the steps below:
 
 1. Copy your certificate and key to certs/nginx.crt and certs/nginx.key
-2. Copy your dhparam file to certs/dhparam.pem
 3. Edit conf/nginx.conf to update `__server_names__` to your domain or IP address
 4. Perform any other configuration edits that you might need
 5. Run `docker build -t sublime_nginx_custom_ssl .`

--- a/nginx-custom-ssl/conf/nginx.conf
+++ b/nginx-custom-ssl/conf/nginx.conf
@@ -17,8 +17,9 @@ http {
 	}
 
 	server {
-		listen 443 ssl http2 default_server;
-		listen [::]:443 ssl http2 default_server;
+		listen 443 ssl default_server;
+		listen [::]:443 ssl default_server;
+		http2 on;
 
 		ssl_certificate /etc/ssl/certs/nginx.crt;
 		ssl_certificate_key /etc/ssl/private/nginx.key;

--- a/nginx-custom-ssl/conf/nginx.conf
+++ b/nginx-custom-ssl/conf/nginx.conf
@@ -18,12 +18,12 @@ http {
 
 	server {
 		listen 443 ssl http2 default_server;
-	        listen [::]:443 ssl http2 default_server;
+		listen [::]:443 ssl http2 default_server;
 
 		ssl_certificate /etc/ssl/certs/nginx.crt;
 		ssl_certificate_key /etc/ssl/private/nginx.key;
 
-	        include ssl-params.conf;
+		include ssl-params.conf;
 
 		location /v1 {
 			proxy_pass http://sublime_mantis:8000;

--- a/nginx-custom-ssl/conf/ssl-params.conf
+++ b/nginx-custom-ssl/conf/ssl-params.conf
@@ -1,21 +1,23 @@
-# from https://cipherli.st/
-# and https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+# adapted from:
+# generated 2026-05-04, Mozilla Guideline v6.0, nginx 1.30, OpenSSL 3.5.5, intermediate config, HSTS
+# https://ssl-config.mozilla.org/#server=nginx&version=1.30&config=intermediate&openssl=3.5.5&hsts&guideline=6.0
 
-ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-ssl_prefer_server_ciphers on;
-ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
-ssl_ecdh_curve secp384r1;
-ssl_session_cache shared:SSL:10m;
-ssl_session_tickets off;
-ssl_stapling on;
-ssl_stapling_verify on;
+# intermediate configuration
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ecdh_curve X25519MLKEM768:X25519:prime256v1:secp384r1;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
+ssl_prefer_server_ciphers off;
+
+# see also ssl_session_ticket_key alternative to stateful session cache
+ssl_session_timeout 1d;
+ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+
 resolver 8.8.8.8 8.8.4.4 valid=300s;
 resolver_timeout 5s;
+
 # Disable preloading HSTS for now.  You can use the commented out header line that includes
 # the "preload" directive if you understand the implications.
 #add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
 add_header Strict-Transport-Security "max-age=63072000; includeSubdomains";
 add_header X-Frame-Options DENY;
 add_header X-Content-Type-Options nosniff;
-
-ssl_dhparam /etc/ssl/certs/dhparam.pem;

--- a/nginx-custom-ssl/conf/ssl-params.conf
+++ b/nginx-custom-ssl/conf/ssl-params.conf
@@ -12,9 +12,6 @@ ssl_prefer_server_ciphers off;
 ssl_session_timeout 1d;
 ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
 
-resolver 8.8.8.8 8.8.4.4 valid=300s;
-resolver_timeout 5s;
-
 # Disable preloading HSTS for now.  You can use the commented out header line that includes
 # the "preload" directive if you understand the implications.
 #add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";

--- a/nginx-letsencrypt/Dockerfile
+++ b/nginx-letsencrypt/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.23.3
+FROM nginx:1.30.0
 
 RUN apt-get update &&  apt-get install -y \
   wget \

--- a/nginx-letsencrypt/start.sh
+++ b/nginx-letsencrypt/start.sh
@@ -35,7 +35,7 @@ sed -i "s/___server_names___/$_server_names/g" /etc/nginx/nginx.conf
 sleep 5
 nginx
 sleep 5
-certbot --nginx ${_args} --text --agree-tos --no-self-upgrade --keep --no-redirect --email $EMAIL_ADDRESS -v -n
+certbot --nginx ${_args} --agree-tos --keep --no-redirect --email "$EMAIL_ADDRESS" -v -n
 nginx -s stop
 sleep 3
 nginx -g "daemon off;"


### PR DESCRIPTION
* Upgrade nginx to a supported version.
* Disable TLSv1 and refresh cipher suite list.
* Remove OCSP stapling since Let's Encrypt has sunset OCSP.

https://www.notion.so/sublimesecurity/35604655fc9d814ab504ec57cd7cbfba