### PR TITLE
Bump platform to 1.88

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sublime_mantis:
-    image: sublimesec/mantis:1.87
+    image: sublimesec/mantis:1.88
     restart: unless-stopped
     container_name: sublime_mantis
     environment:
@@ -29,7 +29,7 @@ services:
       - sublime_strelka_backend
       - sublime_strelka_frontend
   sublime_bora_lite:
-    image: sublimesec/bora-lite:1.87
+    image: sublimesec/bora-lite:1.88
     restart: unless-stopped
     container_name: sublime_bora_lite
     environment:
@@ -70,7 +70,7 @@ services:
     networks:
       - net
   sublime_dashboard:
-    image: sublimesec/dashboard:1.86
+    image: sublimesec/dashboard:1.88
     restart: unless-stopped
 
     container_name: sublime_dashboard


### PR DESCRIPTION
Update Docker images to the 1.88 release.

| Service | Old | New |
|---|---|---|
| `sublimesec/mantis` | 1.87 | 1.88 |
| `sublimesec/bora-lite` | 1.87 | 1.88 |
| `sublimesec/dashboard` | 1.86 | 1.88 |

Backend (go-mantis) and frontend (sublime-dashboard) were both released at 1.88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)