### PR TITLE
Pin minio/mc to mirror

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
   # Keep this name as sublimes3 because underscores don't play nice with certain endpoint validation
   sublimes3:
     container_name: sublimes3
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio
     restart: unless-stopped
     networks:
       - net
@@ -169,7 +169,7 @@ services:
       minio server --address 0.0.0.0:8110 --console-address 0.0.0.0:8111  /data;
       "
   sublime_create_buckets:
-    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc
     depends_on:
       - sublimes3
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
   # Keep this name as sublimes3 because underscores don't play nice with certain endpoint validation
   sublimes3:
     container_name: sublimes3
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     networks:
       - net
@@ -169,7 +169,7 @@ services:
       minio server --address 0.0.0.0:8110 --console-address 0.0.0.0:8111  /data;
       "
   sublime_create_buckets:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       - sublimes3
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
   # Keep this name as sublimes3 because underscores don't play nice with certain endpoint validation
   sublimes3:
     container_name: sublimes3
-    image: quay.io/minio/minio
+    image: cgr.dev/chainguard/minio
     restart: unless-stopped
     networks:
       - net
@@ -169,7 +169,7 @@ services:
       minio server --address 0.0.0.0:8110 --console-address 0.0.0.0:8111  /data;
       "
   sublime_create_buckets:
-    image: quay.io/minio/mc
+    image: cgr.dev/chainguard/minio-client
     depends_on:
       - sublimes3
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
   # Keep this name as sublimes3 because underscores don't play nice with certain endpoint validation
   sublimes3:
     container_name: sublimes3
-    image: cgr.dev/chainguard/minio
+    image: quay.io/minio/minio
     restart: unless-stopped
     networks:
       - net
@@ -169,7 +169,7 @@ services:
       minio server --address 0.0.0.0:8110 --console-address 0.0.0.0:8111  /data;
       "
   sublime_create_buckets:
-    image: cgr.dev/chainguard/minio-client
+    image: quay.io/minio/mc
     depends_on:
       - sublimes3
     networks:


### PR DESCRIPTION
Looks like `minio` was removed from docker's registry causing all of CI to fail.